### PR TITLE
Support for different content widths and heights.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ contentCellBuilder: (i, j) => Text(data[i][j]),
 ```
 
 For more advanced usage - decorate Text with other widgets like borders, cell colors, etc. Check decorated_example.dart to see it in action.
-You can also wrap cell with tap listeners and add custom behavior on tap. Check tap_handler_example.dart. 
+You can also wrap cell with tap listeners and add custom behavior on tap. Check tap_handler_example.dart.
+
+You can also customize the cell dimensions using the cellDimensions property of StickyHeadersTable. Uniform or different cell widths and heights are both supported.
   
 Feature requests and PRs are welcome.  
 

--- a/lib/table_sticky_headers.dart
+++ b/lib/table_sticky_headers.dart
@@ -226,31 +226,79 @@ class _StickyHeadersTableState extends State<StickyHeadersTable> {
 class CellDimensions {
   const CellDimensions({
     /// Content cell width. It also applied to sticky row width.
-    this.contentCellWidth,
-
-    /// Content cell widths - if different width for each content cell needed.
-    /// It is also applied to sticky row widths. Need to specify either
-    /// contentCellWidth or contentCellWidths or assertion will fail.
-    /// Length of list needs to match columnsLength.
-    /// Overrides contentCellWidth if both are specified.
-    this.contentCellWidths,
+    @required this.contentCellWidth,
 
     /// Content cell height. It also applied to sticky column height.
-    this.contentCellHeight,
-
-    /// Content cell heights - if different height for each content cell needed.
-    /// It is also applied to sticky row heights. Need to specify either
-    /// contentCellHeight or contentCellHeights or assertion will fail.
-    /// Length of list needs to match rowsLength.
-    /// Overrides contentCellHeight if both are specified.
-    this.contentCellHeights,
+    @required this.contentCellHeight,
 
     /// Sticky legend width. It also applied to sticky column width.
     @required this.stickyLegendWidth,
 
     /// Sticky legend height/ It also applied to sticky row height.
     @required this.stickyLegendHeight,
-  });
+  })  : this.contentCellWidths = null,
+        this.contentCellHeights = null;
+
+  const CellDimensions.variableWidth({
+    /// Content cell widths - if different width for each content cell needed.
+    /// It is also applied to sticky row widths. Need to specify either
+    /// contentCellWidth or contentCellWidths or assertion will fail.
+    /// Length of list needs to match columnsLength.
+    /// Overrides contentCellWidth if both are specified.
+    @required this.contentCellWidths,
+
+    /// Content cell height. It also applied to sticky column height.
+    @required this.contentCellHeight,
+
+    /// Sticky legend width. It also applied to sticky column width.
+    @required this.stickyLegendWidth,
+
+    /// Sticky legend height/ It also applied to sticky row height.
+    @required this.stickyLegendHeight,
+  })  : this.contentCellWidth = null,
+        this.contentCellHeights = null;
+
+  const CellDimensions.variableHeight({
+    /// Content cell width. It also applied to sticky row width.
+    @required this.contentCellWidth,
+
+    /// Content cell heights - if different height for each content cell needed.
+    /// It is also applied to sticky row heights. Need to specify either
+    /// contentCellHeight or contentCellHeights or assertion will fail.
+    /// Length of list needs to match rowsLength.
+    /// Overrides contentCellHeight if both are specified.
+    @required this.contentCellHeights,
+
+    /// Sticky legend width. It also applied to sticky column width.
+    @required this.stickyLegendWidth,
+
+    /// Sticky legend height/ It also applied to sticky row height.
+    @required this.stickyLegendHeight,
+  })  : this.contentCellWidths = null,
+        this.contentCellHeight = null;
+
+  const CellDimensions.variableWidthAndHeight({
+    /// Content cell widths - if different width for each content cell needed.
+    /// It is also applied to sticky row widths. Need to specify either
+    /// contentCellWidth or contentCellWidths or assertion will fail.
+    /// Length of list needs to match columnsLength.
+    /// Overrides contentCellWidth if both are specified.
+    @required this.contentCellWidths,
+
+    /// Content cell heights - if different height for each content cell needed.
+    /// It is also applied to sticky row heights. Need to specify either
+    /// contentCellHeight or contentCellHeights or assertion will fail.
+    /// Length of list needs to match rowsLength.
+    /// Overrides contentCellHeight if both are specified.
+    @required this.contentCellHeights,
+
+    /// Sticky legend width. It also applied to sticky column width.
+    @required this.stickyLegendWidth,
+
+    /// Sticky legend height/ It also applied to sticky row height.
+    @required this.stickyLegendHeight,
+  })  : this.contentCellWidth = null,
+        this.contentCellHeight = null;
 
   final double contentCellWidth;
   final List<double> contentCellWidths;

--- a/lib/table_sticky_headers.dart
+++ b/lib/table_sticky_headers.dart
@@ -40,6 +40,16 @@ class StickyHeadersTable extends StatefulWidget {
     assert(columnsTitleBuilder != null);
     assert(rowsTitleBuilder != null);
     assert(contentCellBuilder != null);
+    assert(cellDimensions.contentCellWidth != null ||
+        cellDimensions.contentCellWidths != null);
+    assert(cellDimensions.contentCellHeight != null ||
+        cellDimensions.contentCellHeights != null);
+    if (cellDimensions.contentCellWidths != null) {
+      assert(cellDimensions.contentCellWidths.length == columnsLength);
+    }
+    if (cellDimensions.contentCellHeights != null) {
+      assert(cellDimensions.contentCellHeights.length == rowsLength);
+    }
   }
 
   final int rowsLength;
@@ -98,8 +108,10 @@ class _StickyHeadersTableState extends State<StickyHeadersTable> {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: List.generate(
                       widget.columnsLength,
-                          (i) => Container(
-                        width: widget.cellDimensions.contentCellWidth,
+                      (i) => Container(
+                        width: widget.cellDimensions.contentCellWidths != null
+                            ? widget.cellDimensions.contentCellWidths[i]
+                            : widget.cellDimensions.contentCellWidth,
                         height: widget.cellDimensions.stickyLegendHeight,
                         child: FittedBox(
                           fit: widget.cellFit,
@@ -129,9 +141,11 @@ class _StickyHeadersTableState extends State<StickyHeadersTable> {
                   child: Column(
                     children: List.generate(
                       widget.rowsLength,
-                          (i) => Container(
+                      (i) => Container(
                         width: widget.cellDimensions.stickyLegendWidth,
-                        height: widget.cellDimensions.contentCellHeight,
+                        height: widget.cellDimensions.contentCellHeights != null
+                            ? widget.cellDimensions.contentCellHeights[i]
+                            : widget.cellDimensions.contentCellHeight,
                         child: FittedBox(
                           fit: widget.cellFit,
                           child: widget.rowsTitleBuilder(i),
@@ -164,14 +178,24 @@ class _StickyHeadersTableState extends State<StickyHeadersTable> {
                           child: Column(
                             children: List.generate(
                               widget.rowsLength,
-                                  (int i) => Row(
+                              (int i) => Row(
                                 children: List.generate(
                                   widget.columnsLength,
-                                      (int j) => Container(
-                                    width:
-                                    widget.cellDimensions.contentCellWidth,
-                                    height:
-                                    widget.cellDimensions.contentCellHeight,
+                                  (int j) => Container(
+                                    width: widget.cellDimensions
+                                                .contentCellWidths !=
+                                            null
+                                        ? widget
+                                            .cellDimensions.contentCellWidths[j]
+                                        : widget
+                                            .cellDimensions.contentCellWidth,
+                                    height: widget.cellDimensions
+                                                .contentCellHeights !=
+                                            null
+                                        ? widget.cellDimensions
+                                            .contentCellHeights[i]
+                                        : widget
+                                            .cellDimensions.contentCellHeight,
                                     child: FittedBox(
                                       fit: widget.cellFit,
                                       child: widget.contentCellBuilder(j, i),
@@ -202,10 +226,24 @@ class _StickyHeadersTableState extends State<StickyHeadersTable> {
 class CellDimensions {
   const CellDimensions({
     /// Content cell width. It also applied to sticky row width.
-    @required this.contentCellWidth,
+    this.contentCellWidth,
+
+    /// Content cell widths - if different width for each content cell needed.
+    /// It is also applied to sticky row widths. Need to specify either
+    /// contentCellWidth or contentCellWidths or assertion will fail.
+    /// Length of list needs to match columnsLength.
+    /// Overrides contentCellWidth if both are specified.
+    this.contentCellWidths,
 
     /// Content cell height. It also applied to sticky column height.
-    @required this.contentCellHeight,
+    this.contentCellHeight,
+
+    /// Content cell heights - if different height for each content cell needed.
+    /// It is also applied to sticky row heights. Need to specify either
+    /// contentCellHeight or contentCellHeights or assertion will fail.
+    /// Length of list needs to match rowsLength.
+    /// Overrides contentCellHeight if both are specified.
+    this.contentCellHeights,
 
     /// Sticky legend width. It also applied to sticky column width.
     @required this.stickyLegendWidth,
@@ -215,7 +253,9 @@ class CellDimensions {
   });
 
   final double contentCellWidth;
+  final List<double> contentCellWidths;
   final double contentCellHeight;
+  final List<double> contentCellHeights;
   final double stickyLegendWidth;
   final double stickyLegendHeight;
 

--- a/lib/table_sticky_headers.dart
+++ b/lib/table_sticky_headers.dart
@@ -239,12 +239,10 @@ class CellDimensions {
   })  : this.contentCellWidths = null,
         this.contentCellHeights = null;
 
+  /// Use if different width for each content cell is needed.
   const CellDimensions.variableWidth({
-    /// Content cell widths - if different width for each content cell needed.
-    /// It is also applied to sticky row widths. Need to specify either
-    /// contentCellWidth or contentCellWidths or assertion will fail.
+    /// Content cell widths. Also applied to sticky row widths.
     /// Length of list needs to match columnsLength.
-    /// Overrides contentCellWidth if both are specified.
     @required this.contentCellWidths,
 
     /// Content cell height. It also applied to sticky column height.
@@ -258,15 +256,13 @@ class CellDimensions {
   })  : this.contentCellWidth = null,
         this.contentCellHeights = null;
 
+  /// Use if different height for each content cell is needed.
   const CellDimensions.variableHeight({
     /// Content cell width. It also applied to sticky row width.
     @required this.contentCellWidth,
 
-    /// Content cell heights - if different height for each content cell needed.
-    /// It is also applied to sticky row heights. Need to specify either
-    /// contentCellHeight or contentCellHeights or assertion will fail.
+    /// Content cell heights. Also applied to sticky row heights.
     /// Length of list needs to match rowsLength.
-    /// Overrides contentCellHeight if both are specified.
     @required this.contentCellHeights,
 
     /// Sticky legend width. It also applied to sticky column width.
@@ -277,19 +273,14 @@ class CellDimensions {
   })  : this.contentCellWidths = null,
         this.contentCellHeight = null;
 
+  /// Use if different width and height for each content cell is needed.
   const CellDimensions.variableWidthAndHeight({
-    /// Content cell widths - if different width for each content cell needed.
-    /// It is also applied to sticky row widths. Need to specify either
-    /// contentCellWidth or contentCellWidths or assertion will fail.
+    /// Content cell widths. Also applied to sticky row widths.
     /// Length of list needs to match columnsLength.
-    /// Overrides contentCellWidth if both are specified.
     @required this.contentCellWidths,
 
-    /// Content cell heights - if different height for each content cell needed.
-    /// It is also applied to sticky row heights. Need to specify either
-    /// contentCellHeight or contentCellHeights or assertion will fail.
+    /// Content cell heights. Also applied to sticky row heights.
     /// Length of list needs to match rowsLength.
-    /// Overrides contentCellHeight if both are specified.
     @required this.contentCellHeights,
 
     /// Sticky legend width. It also applied to sticky column width.


### PR DESCRIPTION
User can specify the List<double> contentCellWidths and List<double> contentCellHeights in CellDimensions to create a table with different content cell widths and heights. The contentCellWidth and contentCellHeight parameters, as well as the base values still work as before, so the update is backwards compatible. There are checks so that the user has to specify either contentCellWidths or contentCellWidth, and either contentCellHeights or contentCellHeight, if setting the Cell Dimensions. Also, if setting contentCellWidths, the length of the list should match columnsLength and the length of contentCellHeights should match rowsLength. If both contentCellWidths and contentCellWidth are specified, the list takes priority. Same for contentCellHeights.